### PR TITLE
Fix xml maker mapping save and load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 
+
+/.idea/
+/*.xsd

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
+    <modelVersion>4.0.0</modelVersion>
+
     <groupId>org.hupo.psi.mi.tools</groupId>
     <artifactId>xmlMakerFlattener</artifactId>
     <packaging>jar</packaging>
 
-    <version>2.2</version>
-
-    <modelVersion>4.0.0</modelVersion>
+    <version>2.2.1</version>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -28,15 +28,15 @@
                     <descriptors>
                         <descriptor>src/main/resources/assembly.xml</descriptor>
                     </descriptors>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>assembly</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>assembly</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
@@ -52,6 +52,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>
+                <version>2.1.0</version>
                 <configuration>
                     <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
                     <binPrefix>psi</binPrefix>
@@ -65,14 +66,7 @@
                         <platform>windows</platform>
                         <platform>unix</platform>
                     </platforms>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>assemble</goal>
-                            </goals>
-                        </execution>
-                    </executions>
+
                     <programs>
                         <program>
                             <mainClass>psidev.psi.mi.filemakers.xmlFlattener.XmlFlattener</mainClass>
@@ -92,6 +86,14 @@
                         </program>						
                     </programs>
                 </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>assemble</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/readme
+++ b/readme
@@ -41,7 +41,7 @@ Linux:
       sh bin/xmlmaker -mapping <mapping-file.xml>   -o <output xmlDocument>  -dictionaries <dictionaries>  -flatfiles <flat files>
 
 
-    * Maker without Graphical User Interface:
+    * Maker with Graphical User Interface:
 
       sh bin/xmlmaker-gui
 

--- a/scripts/map-folder.sh
+++ b/scripts/map-folder.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if ["$#" -ne 3]; then
+    echo "USAGE ./map-folder.sh INPUT_FOLDER MAPPING_FILE OUTPUT_FOLDER"
+    echo ""
+    echo "INPUT_FOLDER can contain the prefix of the flat files"
+    echo "MAPPING_FILE is an XML file created by XMLMaker after saving a mapping"
+    echo "OUTPUT_FOLDER is the path to which the generated xml should be put in"
+    exit 1;
+fi
+
+INPUT_FOLDER=$1
+MAPPING_FILE=$2
+OUTPUT_FOLDER=$3
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+for FILE in ${INPUT_FOLDER}*;
+do
+    FILENAME=$(basename -- "$FILE")
+    ${SCRIPT_DIR}/../target/xmlMakerFlattener/bin/xmlmaker \
+        -flatfiles ${FILE} \
+        -mapping ${MAPPING_FILE} \
+        -o "${OUTPUT_FOLDER}/$(echo "${FILENAME}" | sed 's/[tc]sv/xml/g')"
+done;

--- a/scripts/map-folder.sh
+++ b/scripts/map-folder.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ["$#" -ne 3]; then
+if [ "$#" -ne 3 ]; then
     echo "USAGE ./map-folder.sh INPUT_FOLDER MAPPING_FILE OUTPUT_FOLDER"
     echo ""
     echo "INPUT_FOLDER can contain the prefix of the flat files"


### PR DESCRIPTION
Fix issues saving and load mapping when using the XML maker.

Issues:
- When saving a mapping, the mapping set for 'bibref' was not being saved.
- When loading a mapping, the mapping set for 'interactionList' was not being loaded.

Issues were related to the schema having a sequence with a single choice of a choice with a sequence as one of the options.